### PR TITLE
Intel issue DPD200416083

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "PGI" )
   set(portland_group_compiler true)
 elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Cray" )
   set(cray_compiler true)
+elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel" )
+  set(intel_compiler true)
 endif()
 
 include(AddCompileTimeTest.cmake)
@@ -55,6 +57,8 @@ elseif("${portland_group_compiler}")
 elseif("${cray_compiler}")
   add_compile_time_test(cce-bug-821337 src/cce/nasa/bug-821337 generic-resolution f90)
   add_cmake_test(cmake-bug-xxxxx src/cmake/bug-xxxxx)
+elseif("${intel_compiler}")
+  add_compile_time_test(intel-issue-DPD200416083 src/intel/issue-DPD200416083 oop-caf f90)
 else()
   message(FATAL_ERROR
     "\n"

--- a/src/intel/issue-DPD200416083/oop-caf.f90
+++ b/src/intel/issue-DPD200416083/oop-caf.f90
@@ -1,0 +1,39 @@
+module wrapped_classes
+  implicit none
+  private
+  public :: wrapped_coarray
+
+  type :: wrapped_point
+    integer, allocatable :: point(:)
+    contains
+      procedure :: add => wrapped_point_add
+  end type wrapped_point
+
+  type :: wrapped_coarray
+    type(wrapped_point), allocatable :: caf(:)[:]
+  end type wrapped_coarray
+
+  contains
+
+    subroutine wrapped_point_add(self, to_add)
+      class(wrapped_point), intent(inout) :: self
+      integer,              intent(in)    :: to_add
+
+      if (allocated(self%point)) then
+        self%point = [self%point, to_add]
+      else
+        self%point = [to_add]
+      end if
+    end subroutine wrapped_point_add
+end module wrapped_classes
+
+program test
+  use wrapped_classes
+  implicit none
+
+  type(wrapped_coarray) :: foo
+  allocate(foo%caf(99)[*])
+  call foo%caf(32)%add(this_image())
+  print*, foo%caf(32)%point
+end program test
+


### PR DESCRIPTION
CAF wrapped into OOP

Intel Fortran Compiler seems to be confused when calling a TBP associated to a coarray component of a derived type. When the `add` TBP of the test is invoked a SIGSEGV is generated.

This is currently an official issue for which deeper investigations are pending, but not yet an official bug.

I reproduced the issue with Intel v. 16.0.3 and 17.0.1, under GNU Linux distro (with Arch Linux and Ubuntu).

#### CMakeLists.txt

I have tried to modify the CMake build system to add this test, but I am not sure about the results I obtained.

> I cannot find a previous example of Intel test into the original CMakeLists.txt, thus I am gone by *nose*...

Signed-off-by: Stefano Zaghi <stefano.zaghi@gmail.com>